### PR TITLE
Cf/102 send email

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -31,6 +31,7 @@ graphene>=2.0
 graphene-django>=2.0
 psycopg2-binary
 dj-database-url
+sendgrid
 
 # Testing/Linting
 pylint==1.9.2 # Necessary for open bug (as of 2-10-18): https://github.com/PyCQA/pylint/issues/2315

--- a/backend/server/management/commands/send_email.py
+++ b/backend/server/management/commands/send_email.py
@@ -1,16 +1,29 @@
-from datetime import datetime, timezone
+import os
+from datetime import datetime, timezone, date
 
 from django.core.management.base import BaseCommand
+from django.template.loader import get_template
+import sendgrid
+from sendgrid.helpers.mail import Email, Content, Mail
 
 from server.models import Match, Prediction
 
 JAN = 1
 FIRST = 1
+EMAIL_FROM = "tips@tipresias.com"
+PREDICTION_HEADERS = [
+    "Date",
+    "Home Team",
+    "Away Team",
+    "Predicted Winner",
+    "Predicted Margin",
+]
 
 
 class Command(BaseCommand):
     """
-    manage.py command for 'send_email' that sends an email with the most recent predictions AFL matches
+    manage.py command for 'send_email' that sends an email with the most recent predictions
+    AFL matches
     """
 
     help = """
@@ -41,14 +54,44 @@ class Command(BaseCommand):
             .order_by("match__start_date_time")
         )
 
-        prediction_headers = [
-            ["date", "home_team", "away_team", "predicted_winner", "predicted_margin"]
-        ]
         prediction_rows = [
             self.__map_prediction_to_row(prediction)
             for prediction in latest_round_predictions
         ]
-        prediction_table = prediction_headers + prediction_rows
+
+        prediction_mail_params = {
+            "prediction_headers": PREDICTION_HEADERS,
+            "prediction_rows": prediction_rows,
+            "round_number": latest_round,
+        }
+
+        email_template = get_template("tip_mail.html")
+        email_body = email_template.render(prediction_mail_params)
+
+        email_recipient = os.environ.get("EMAIL_RECIPIENT")
+        api_key = os.environ.get("SENDGRID_API_KEY")
+
+        if email_recipient is None:
+            raise ValueError(
+                "No email recipient was defined. Be sure to define the environment variable "
+                "'EMAIL_RECIPIENT' in order to send tips emails."
+            )
+
+        if api_key is None:
+            raise ValueError(
+                "The Sendgrid API key wasn't defined. Be sure to define the environment variable "
+                "'SENDGRID_API_KEY' in order to send tips emails."
+            )
+
+        from_email = Email(EMAIL_FROM)
+        to_email = Email(email_recipient)
+        subject = f"Footy Tips for {date.today()}"
+        content = Content("text/html", email_body)
+        mail = Mail(from_email, subject, to_email, content)
+
+        sendgrid.SendGridAPIClient(apikey=api_key).client.mail.send.post(
+            request_body=mail.get()
+        )
 
     @staticmethod
     def __map_prediction_to_row(prediction: Prediction):

--- a/backend/server/management/commands/send_email.py
+++ b/backend/server/management/commands/send_email.py
@@ -1,0 +1,65 @@
+from datetime import datetime, timezone
+
+from django.core.management.base import BaseCommand
+
+from server.models import Match, Prediction
+
+JAN = 1
+FIRST = 1
+
+
+class Command(BaseCommand):
+    """
+    manage.py command for 'send_email' that sends an email with the most recent predictions AFL matches
+    """
+
+    help = """
+    Send email with predictions for most-recent round predicted (either the upcoming round
+    or most recently-played round).
+    """
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
+    def handle(self, *_args, **_kwargs):
+        """Run 'send_email' command"""
+
+        latest_match = Match.objects.latest("start_date_time")
+        latest_year = latest_match.start_date_time.year
+        latest_round = latest_match.round_number
+
+        latest_round_predictions = (
+            Prediction.objects.filter(
+                ml_model__name="tipresias",
+                match__start_date_time__gt=datetime(
+                    latest_year, JAN, FIRST, tzinfo=timezone.utc
+                ),
+                match__round_number=latest_round,
+            )
+            .select_related("match")
+            .prefetch_related("match__teammatch_set")
+            .order_by("match__start_date_time")
+        )
+
+        prediction_headers = [
+            ["date", "home_team", "away_team", "predicted_winner", "predicted_margin"]
+        ]
+        prediction_rows = [
+            self.__map_prediction_to_row(prediction)
+            for prediction in latest_round_predictions
+        ]
+        prediction_table = prediction_headers + prediction_rows
+
+    @staticmethod
+    def __map_prediction_to_row(prediction: Prediction):
+        match = prediction.match
+        home_team = match.teammatch_set.get(at_home=True).team.name
+        away_team = match.teammatch_set.get(at_home=False).team.name
+
+        return [
+            str(match.start_date_time),
+            home_team,
+            away_team,
+            prediction.predicted_winner.name,
+            prediction.predicted_margin,
+        ]

--- a/backend/server/templates/tip_mail.html
+++ b/backend/server/templates/tip_mail.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <div>
+      <h3>Tips for Round {{ round_number }}</h3>
+      <table>
+        <thead>
+          {% for header in prediction_headers %}
+          <th>{{ header }}</th>
+          {% endfor %}
+        </thead>
+        <tbody>
+          {% for row in prediction_rows %}
+          <tr>
+            {% for element in row %}
+            <td>{{ element }}</td>
+            {% endfor %}
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </body>
+</html>

--- a/backend/server/tests/integration/management/commands/test_send_email.py
+++ b/backend/server/tests/integration/management/commands/test_send_email.py
@@ -1,0 +1,86 @@
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+from django.test import TestCase
+from faker import Faker
+
+from server.data_config import TEAM_NAMES
+from server.models import Match, Team, TeamMatch, Prediction, MLModel
+from server.management.commands import send_email
+
+FAKE = Faker()
+ROW_COUNT = 10
+
+
+class TestSendEmail(TestCase):
+    def setUp(self):
+        today = datetime.now(tz=timezone.utc)
+        year = today.year
+        team_names = TEAM_NAMES[:]
+
+        self.fixture_data = [
+            {
+                "date": today,
+                "season": year,
+                "round": 1,
+                "round_label": "Round 1",
+                "crows": 1234,
+                "home_team": team_names.pop(),
+                "away_team": team_names.pop(),
+                "home_score": 50,
+                "away_score": 100,
+                "venue": FAKE.city(),
+            }
+            for idx in range(ROW_COUNT)
+        ]
+
+        # Save records in DB
+        ml_model = MLModel(name="tipresias")
+        ml_model.save()
+
+        for match_data in self.fixture_data:
+            match = Match(
+                start_date_time=match_data["date"],
+                round_number=match_data["round"],
+                venue=match_data["venue"],
+            )
+            match.save()
+
+            home_team = Team(name=match_data["home_team"])
+            home_team.save()
+            away_team = Team(name=match_data["away_team"])
+            away_team.save()
+
+            home_team_match = TeamMatch(
+                team=home_team,
+                match=match,
+                at_home=True,
+                score=match_data["home_score"],
+            )
+            home_team_match.save()
+            away_team_match = TeamMatch(
+                team=away_team,
+                match=match,
+                at_home=False,
+                score=match_data["away_score"],
+            )
+            away_team_match.save()
+
+            Prediction(
+                ml_model=ml_model,
+                match=match,
+                predicted_winner=home_team,
+                predicted_margin=50,
+            ).save()
+
+        self.send_email_command = send_email.Command()
+
+    def test_handle(self):
+        with patch("sendgrid.SendGridAPIClient") as MockClient:
+            MockClient.return_value.client.return_value.mail.return_value.send.return_value.post = (
+                lambda x: x
+            )
+
+            self.send_email_command.handle()
+
+            MockClient.assert_called()

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -12,6 +12,8 @@ services:
     environment:
       - DJANGO_SETTINGS_MODULE=project.settings.development
       - DATABASE_HOST=db
+      - EMAIL_RECIPIENT=test@test.com
+      - SENDGRID_API_KEY=test
     command: python3 manage.py runserver 0.0.0.0:8000
   frontend:
     image: cfranklin11/tipresias_client:master

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
     tty: true
     depends_on:
       - db
+    env_file: ./backend/.env
     environment:
       - DJANGO_SETTINGS_MODULE=project.settings.development
       - DATABASE_HOST=db


### PR DESCRIPTION
Collect tips from latest round in the DB (played or unplayed) and send email with basic match info and predicted winner & margin. Triggered via django command.