### PR TITLE
Cf/fix duplicate matches

### DIFF
--- a/backend/server/management/commands/tip.py
+++ b/backend/server/management/commands/tip.py
@@ -179,7 +179,9 @@ class Command(BaseCommand):
 
         # 'make_aware' raises error if datetime already has a timezone
         if raw_date.tzinfo is None or raw_date.tzinfo.utcoffset(raw_date) is None:
-            match_date = utils.timezone.make_aware(raw_date)
+            match_date = utils.timezone.make_aware(
+                raw_date, timezone=MELBOURNE_TIMEZONE
+            )
         else:
             match_date = raw_date
 


### PR DESCRIPTION
For some reason I wasn't skipping match creation on subsequent `tip` runs in a given week. It wasn't creating duplicates before, but with the recent timezone changes, the script was just creating new matches every time. Since duplicate matches are bad, and there's no reason to waste time on querying & creating match records if we already have them anyway, I'm just putting that logic behind a conditional.