### PR TITLE
Change django timezone to AU/Melb

### DIFF
--- a/backend/project/settings/common.py
+++ b/backend/project/settings/common.py
@@ -110,7 +110,7 @@ MELBOURNE_TIMEZONE = timezone(timedelta(hours=HOURS_FROM_UTC_TO_MELBOURNE))
 
 LANGUAGE_CODE = "en-us"
 
-TIME_ZONE = "UTC"
+TIME_ZONE = "Australia/Melbourne"
 
 USE_I18N = True
 


### PR DESCRIPTION
I think the fact that Django thinks we're on UTC is making the cron jobs not work, so at least making it correct, so all timezone things are set to 'Australia/Melbourne'