### PR TITLE
Cf/106 data performance

### DIFF
--- a/backend/machine_learning/data_import/afl_data_importer.py
+++ b/backend/machine_learning/data_import/afl_data_importer.py
@@ -1,8 +1,9 @@
 """Module for scraping data from afl.com.au"""
 
-from typing import Optional, Dict, List
+from typing import Optional, Dict, List, Tuple
 import itertools
-from datetime import date
+import re
+from datetime import date, datetime
 import warnings
 from urllib.parse import urljoin
 from bs4 import BeautifulSoup, element
@@ -10,8 +11,13 @@ import requests
 import pandas as pd
 
 from machine_learning.data_config import TEAM_TRANSLATIONS
+from project.settings.common import MELBOURNE_TIMEZONE
 
 AFL_DOMAIN = "https://www.afl.com.au"
+# afl.com.au always lists the home team first, which is standard convention across
+# data sources
+HOME_TEAM_IDX = 0
+AWAY_TEAM_IDX = 1
 
 
 def _translate_team_name(team_name: str):
@@ -21,40 +27,49 @@ def _translate_team_name(team_name: str):
     return team_name
 
 
-def _parse_player_data(player_element: element) -> str:
-    return list(player_element.stripped_strings)[-1]
+def _parse_team_data(team_element: element) -> Tuple[str, List[Dict[str, str]]]:
+    team_player_labels = itertools.islice(team_element.stripped_strings, None, None, 2)
+
+    team_name = next(team_player_labels)
+
+    return (
+        team_name,
+        [
+            {"playing_for": team_name, "player_name": player_name}
+            for player_name in team_player_labels
+        ],
+    )
 
 
-def _parse_team_data(
-    game_element: element, team_element: element
+def _parse_game_datetime(game_element: element) -> datetime:
+    game_time = list(game_element.stripped_strings)[-1]
+    game_time_with_blanks_removed = re.sub(r"^[^\d]+", "", game_time)
+    game_datetime_string = re.sub(r"(pm|am)[^,]+", "\\1", game_time_with_blanks_removed)
+
+    return datetime.strptime(game_datetime_string, "%I:%M%p, %B %d, %Y")
+
+
+def _parse_game_data(
+    game_index: int, game_element: element, roster_element: element
 ) -> List[Dict[str, str]]:
-    team_name = next(team_element.stripped_strings)
-    team_number = "1" if "team1" in team_element["class"] else "2"
+    game_datetime = _parse_game_datetime(game_element)
+    team_elements = roster_element.select("ul")
 
-    player_selector = f"#fieldInouts .posGroup .team{team_number} .player"
-
-    return [
-        {"playing_for": team_name, "player_name": _parse_player_data(player_element)}
-        for player_element in game_element.select(player_selector)
+    team_player_data = [
+        _parse_team_data(team_element) for team_element in team_elements
     ]
+    team_names, player_lists = zip(*team_player_data)
 
-
-def _parse_game_data(game_index: int, game_element: element) -> List[Dict[str, str]]:
-    team_elements = game_element.select(".lineup-detail .team-logo")
-    team_names = [team_element.stripped_strings for team_element in team_elements]
     game_data = {
-        "home_team": next(team_names[0]),
-        "away_team": next(team_names[1]),
+        "date": game_datetime,
         "match_id": str(game_index),
+        "home_team": team_names[HOME_TEAM_IDX],
+        "away_team": team_names[AWAY_TEAM_IDX],
     }
-
-    player_data_lists = [
-        _parse_team_data(game_element, team_element) for team_element in team_elements
-    ]
 
     return [
         {**game_data, **player_data}
-        for player_data in itertools.chain.from_iterable(player_data_lists)
+        for player_data in itertools.chain.from_iterable(player_lists)
     ]
 
 
@@ -62,34 +77,37 @@ def _fetch_rosters(round_number: Optional[int]) -> List[Dict[str, str]]:
     round_param = {} if round_number is None else {"round": round_number}
     response = requests.get(urljoin(AFL_DOMAIN, "news/teams"), params=round_param)
     soup = BeautifulSoup(response.text, "html5lib")
-    game_elements = soup.select(".game")
+    game_elements = soup.select("#tteamlist .lineup-detail .game-time")
+    roster_elements = soup.select("#tteamlist .list-inouts")
 
-    if not any(game_elements):
+    if not any(game_elements) or not any(roster_elements):
         warnings.warn(
-            "Could not find any game data. This is likely due to round number "
-            f"{round_number} not having any data yet. Returning an empty list."
+            "Could not find any game  or roster data. This is likely due to round "
+            f"number {round_number} not having any data yet. Returning an empty list."
         )
         return []
 
     round_data = [
-        _parse_game_data(game_index, game_element)
-        for game_index, game_element in enumerate(game_elements)
+        _parse_game_data(game_index, game_element, roster_element)
+        for game_index, (game_element, roster_element) in enumerate(
+            zip(game_elements, roster_elements)
+        )
     ]
 
     return list(itertools.chain.from_iterable(round_data))
 
 
 def get_rosters(
-    round_number: Optional[int] = None, year: Optional[int] = None
+    round_number: int, year: Optional[int] = date.today().year
 ) -> pd.DataFrame:
     """Fetches roster data for the upcoming round from afl.com.au"""
 
-    year = date.today().year if year is None else year
     roster_data = _fetch_rosters(round_number)
 
     if not any(roster_data):
         return pd.DataFrame(
             columns=[
+                "date",
                 "round_number",
                 "year",
                 "match_id",

--- a/backend/machine_learning/data_import/afl_data_importer.py
+++ b/backend/machine_learning/data_import/afl_data_importer.py
@@ -11,7 +11,6 @@ import requests
 import pandas as pd
 
 from machine_learning.data_config import TEAM_TRANSLATIONS
-from project.settings.common import MELBOURNE_TIMEZONE
 
 AFL_DOMAIN = "https://www.afl.com.au"
 # afl.com.au always lists the home team first, which is standard convention across
@@ -73,7 +72,7 @@ def _parse_game_data(
     ]
 
 
-def _fetch_rosters(round_number: Optional[int]) -> List[Dict[str, str]]:
+def _fetch_rosters(round_number: int) -> List[Dict[str, str]]:
     round_param = {} if round_number is None else {"round": round_number}
     response = requests.get(urljoin(AFL_DOMAIN, "news/teams"), params=round_param)
     soup = BeautifulSoup(response.text, "html5lib")

--- a/backend/machine_learning/data_import/footywire_data_importer.py
+++ b/backend/machine_learning/data_import/footywire_data_importer.py
@@ -8,7 +8,6 @@ from datetime import date
 from urllib.parse import urljoin
 from functools import partial
 from urllib3.exceptions import SystemTimeWarning
-import dateutil
 import requests
 from bs4 import BeautifulSoup, element
 import numpy as np
@@ -366,8 +365,10 @@ class FootywireDataImporter:
     @staticmethod
     def __convert_string_cols_to_numeric(cols_to_convert: List[str]) -> pd.DataFrame:
         converted_column_assignments = {
-            col: lambda df: pd.to_numeric(df[col], errors="coerce").fillna(0)
-            for col in cols_to_convert
+            col_name: lambda df, col=col_name: pd.to_numeric(
+                df[col], errors="coerce"
+            ).fillna(0)
+            for col_name in cols_to_convert
         }
 
         return lambda df: df.assign(**converted_column_assignments)

--- a/backend/machine_learning/data_import/footywire_data_importer.py
+++ b/backend/machine_learning/data_import/footywire_data_importer.py
@@ -109,8 +109,8 @@ class FootywireDataImporter:
         """
 
         if fetch_data:
-            return self.__clean_betting_data_frame(
-                self.__fetch_data(BETTING_PATH, year_range)
+            return self.__fetch_data(BETTING_PATH, year_range).pipe(
+                self.__clean_betting_data_frame
             )
 
         return self.__read_data_csv(self.betting_filename, year_range)
@@ -265,13 +265,8 @@ class FootywireDataImporter:
                 .rename(columns={0: "home_score", 1: "away_score"})
                 # For unplayed matches we convert scores to numeric, filling the resulting
                 # NaNs with 0
-                .assign(
-                    home_score=lambda df: pd.to_numeric(
-                        df["home_score"], errors="coerce"
-                    ),
-                    away_score=lambda df: pd.to_numeric(
-                        df["away_score"], errors="coerce"
-                    ),
+                .pipe(
+                    self.__convert_string_cols_to_numeric(["home_score", "away_score"])
                 )
                 .fillna(0)
             )
@@ -293,8 +288,8 @@ class FootywireDataImporter:
                 # for consistency with fitzRoy column labels.
                 round_label=lambda df: df["round"],
                 round=self.__round_number,
-                crowd=lambda df: pd.to_numeric(df["crowd"], errors="coerce").fillna(0),
             )
+            .pipe(self.__convert_string_cols_to_numeric(["crowd"]))
             .astype({"season": int})
         )
 
@@ -314,9 +309,11 @@ class FootywireDataImporter:
                 round_label=lambda df: df["round"],
                 round=self.__round_number,
             )
-            # Matches from betting data page don't have times, but the parser spuriously
-            # assigns one, so we're converting back to basic dates
-            .assign(date=lambda df: df["date"].dt.date)
+            .pipe(
+                self.__convert_string_cols_to_numeric(
+                    ["score", "margin", "win_paid", "line_paid"]
+                )
+            )
         )
 
         merged_df = (
@@ -334,9 +331,12 @@ class FootywireDataImporter:
                     "home_line_odds": float,
                     "away_win_odds": float,
                     "away_line_odds": float,
+                    "home_score": float,
+                    "away_score": float,
                 }
             )
         )
+
         sorted_cols = BETTING_MATCH_COLS + [
             col for col in merged_df.columns if col not in BETTING_MATCH_COLS
         ]
@@ -362,6 +362,15 @@ class FootywireDataImporter:
         return yearly_round_col.map(
             partial(self.__parse_round_label, max_regular_round)
         )
+
+    @staticmethod
+    def __convert_string_cols_to_numeric(cols_to_convert: List[str]) -> pd.DataFrame:
+        converted_column_assignments = {
+            col: lambda df: pd.to_numeric(df[col], errors="coerce").fillna(0)
+            for col in cols_to_convert
+        }
+
+        return lambda df: df.assign(**converted_column_assignments)
 
     @staticmethod
     def __betting_row(max_len: int, tr: element.Tag) -> List[Optional[str]]:
@@ -410,13 +419,9 @@ class FootywireDataImporter:
 
     @staticmethod
     def __parse_dates(data_frame: pd.DataFrame) -> pd.Series:
-        # Need to add season to yearless date; otherwise, the date parser thinks they're
-        # all in the current year.
-        # MyPy doesn't recognize that dateutil has a 'parser' attribute
-        return (
+        # Betting dates aren't displayed with years on the page, so we have to add them
+        return pd.to_datetime(
             data_frame["date"] + " " + data_frame["season"].astype(int).astype(str)
-        ).map(
-            dateutil.parser.parse  # type: ignore
         )
 
     @staticmethod

--- a/backend/machine_learning/data_processors/feature_builder.py
+++ b/backend/machine_learning/data_processors/feature_builder.py
@@ -5,8 +5,6 @@ from machine_learning.types import DataFrameTransformer
 from machine_learning.data_config import INDEX_COLS
 from machine_learning.utils import DataTransformerMixin
 
-REQUIRED_COLS: List[str] = INDEX_COLS + ["oppo_team"]
-
 
 class FeatureBuilder(DataTransformerMixin):
     """Add features to data frames.

--- a/backend/machine_learning/data_processors/feature_builder.py
+++ b/backend/machine_learning/data_processors/feature_builder.py
@@ -27,13 +27,18 @@ class FeatureBuilder(DataTransformerMixin):
     def transform(self, data_frame: pd.DataFrame) -> pd.DataFrame:
         """Add new features to the given data frame."""
 
-        required_cols = REQUIRED_COLS + self.index_cols
+        required_column_set = set(self.index_cols)
+        data_frame_column_set = set(data_frame.columns)
 
-        if any((req_col not in data_frame.columns for req_col in required_cols)):
+        if (
+            required_column_set.intersection(data_frame_column_set)
+            != required_column_set
+        ):
             raise ValueError(
-                "To calculate opposition column, all required columns "
-                f"({required_cols}) must be in data frame, "
-                f"but the columns given were {data_frame.columns}"
+                "To calculate new features, all required columns must be in the "
+                "data frame.\n"
+                f"Required columns: {required_column_set}"
+                f"Columns given: {data_frame_column_set}"
             )
 
         return self._compose_transformers(  # pylint: disable=E1102

--- a/backend/machine_learning/data_processors/player_data_aggregator.py
+++ b/backend/machine_learning/data_processors/player_data_aggregator.py
@@ -30,7 +30,7 @@ STATS_COLS = [
     "last_year_brownlow_votes",
 ]
 
-REQUIRED_COLS = ["oppo_team", "player_id", "player_name"] + STATS_COLS
+REQUIRED_COLS = ["oppo_team", "player_id", "player_name", "date"] + STATS_COLS
 
 
 class PlayerDataAggregator:
@@ -77,7 +77,7 @@ class PlayerDataAggregator:
             data_frame.drop(["player_id", "player_name"], axis=1)
             # Adding some non-index columns in the groupby, because it doesn't change
             # the grouping and makes it easier to keep for the final data frame.
-            .groupby(self.index_cols + ["oppo_team"]).aggregate(
+            .groupby(self.index_cols + ["oppo_team", "date"]).aggregate(
                 self.__aggregations(match_stats_cols)
             )
         )

--- a/backend/machine_learning/data_processors/player_data_aggregator.py
+++ b/backend/machine_learning/data_processors/player_data_aggregator.py
@@ -98,6 +98,7 @@ class PlayerDataAggregator:
         return (
             agg_data_frame.dropna()
             .reset_index()
+            .sort_values("date")
             .drop_duplicates(subset=self.index_cols, keep="last")
             .astype({match_col: int for match_col in match_stats_cols})
             .set_index(self.index_cols, drop=False)

--- a/backend/machine_learning/data_processors/player_data_stacker.py
+++ b/backend/machine_learning/data_processors/player_data_stacker.py
@@ -39,10 +39,11 @@ class PlayerDataStacker:
         return pd.concat(team_dfs, sort=True).drop(["match_id", "playing_for"], axis=1)
 
     def __team_df(self, data_frame: pd.DataFrame, team_type: str) -> pd.DataFrame:
-        return self.__sort_columns(
+        return (
             data_frame[data_frame["playing_for"] == data_frame[f"{team_type}_team"]]
             .rename(columns=self.__replace_col_names(team_type))
             .assign(at_home=1 if team_type == "home" else 0)
+            .pipe(self.__sort_columns)
         )
 
     @staticmethod

--- a/backend/machine_learning/data_processors/team_data_stacker.py
+++ b/backend/machine_learning/data_processors/team_data_stacker.py
@@ -44,13 +44,15 @@ class TeamDataStacker:
 
         return (
             pd.concat(team_dfs, join="inner")
+            .sort_values("date", ascending=True)
             # Various finals matches have been draws and replayed,
             # and sometimes home/away is switched requiring us to drop duplicates
             # at the end.
             # This eliminates some matches from Round 15 in 1897, because they
             # played some sort of round-robin tournament for finals, but I'm
             # not too worried about the loss of that data.
-            .drop_duplicates(subset=self.index_cols, keep="last").sort_index()
+            .drop_duplicates(subset=self.index_cols, keep="last")
+            .sort_index()
         )
 
     def __team_df(self, data_frame: pd.DataFrame, team_type: str) -> pd.DataFrame:
@@ -70,9 +72,6 @@ class TeamDataStacker:
             .assign(at_home=at_home_col)
             .set_index(self.index_cols, drop=False)
             .rename_axis([None] * len(self.index_cols))
-            # Gotta drop duplicates, because St Kilda & Carlton tied a Grand Final
-            # in 2010 and had to replay it, so let's just pretend that never happened
-            .drop_duplicates(subset=self.index_cols, keep="last")
         )
 
     @staticmethod

--- a/backend/machine_learning/data_transformation/data_cleaning.py
+++ b/backend/machine_learning/data_transformation/data_cleaning.py
@@ -214,14 +214,7 @@ def clean_match_data(
         .astype({"year": int, "round_number": int})
         .pipe(
             _filter_out_dodgy_data(
-                duplicate_subset=[
-                    "date",
-                    "venue",
-                    "year",
-                    "round_number",
-                    "home_team",
-                    "away_team",
-                ]
+                duplicate_subset=["year", "round_number", "home_team", "away_team"]
             )
         )
         .assign(match_id=_convert_id_to_string("match_id"))
@@ -310,7 +303,11 @@ def clean_player_data(
             on=["date", "venue"],
             how="left",
         )
-        .pipe(_filter_out_dodgy_data(["year", "round_number", "player_id"]))
+        .pipe(
+            _filter_out_dodgy_data(
+                duplicate_subset=["year", "round_number", "player_id"]
+            )
+        )
         .drop("venue", axis=1)
         # brownlow_votes aren't known until the end of the season
         .fillna({"brownlow_votes": 0})

--- a/backend/machine_learning/data_transformation/data_cleaning.py
+++ b/backend/machine_learning/data_transformation/data_cleaning.py
@@ -334,7 +334,12 @@ def clean_player_data(
 
 
 def clean_joined_data(data_frames: List[pd.DataFrame]):
-    joined_data_frame = pd.concat(data_frames, axis=1)
-    duplicate_columns = joined_data_frame.columns.duplicated()
+    # We need to sort by length (going from longest to shortest), then keeping first
+    # duplicated column to make sure we don't lose earlier values of shared columns
+    # (e.g. dropping match data's 'date' column in favor of the betting data 'date'
+    # column results in lots of NaT values, because betting data only goes back to 2010)
+    sorted_data_frames = sorted(data_frames, key=len, reverse=True)
+    joined_data_frame = pd.concat(sorted_data_frames, axis=1)
+    duplicate_columns = joined_data_frame.columns.duplicated(keep="first")
 
     return joined_data_frame.loc[:, ~duplicate_columns]

--- a/backend/machine_learning/data_transformation/data_cleaning.py
+++ b/backend/machine_learning/data_transformation/data_cleaning.py
@@ -304,7 +304,9 @@ def clean_player_data(
         # from match_results. Also, match_results round_numbers integers rather than
         # a mix of ints and strings.
         .merge(
-            clean_match_data(match_data)[["date", "venue", "round_number", "match_id"]],
+            match_data.pipe(clean_match_data).loc[
+                :, ["date", "venue", "round_number", "match_id"]
+            ],
             on=["date", "venue"],
             how="left",
         )

--- a/backend/machine_learning/ml_data/base_ml_data.py
+++ b/backend/machine_learning/ml_data/base_ml_data.py
@@ -100,7 +100,11 @@ class BaseMLData:
         features = data_frame.drop(label_cols, axis=1)
 
         numeric_features = features.select_dtypes("number").astype(float)
-        categorical_features = features.select_dtypes(exclude=["number", "datetime"])
+        categorical_features = features.select_dtypes(
+            # Excluding datetime for now, as it's useful for data processing, but isn't
+            # a feature in the models
+            exclude=["number", "datetime64[ns, tz]", "datetime"]
+        )
 
         # Sorting columns with categorical features first to allow for positional indexing
         # for some data transformations further down the pipeline

--- a/backend/machine_learning/ml_data/joined_ml_data.py
+++ b/backend/machine_learning/ml_data/joined_ml_data.py
@@ -91,7 +91,9 @@ class JoinedMLData(BaseMLData, DataTransformerMixin):
             self.data_readers["match"].fetch_data = self.fetch_data
             match_data = self.data_readers["match"].data
             self.data_readers["betting"].fetch_data = self.fetch_data
-            betting_data = self.data_readers["betting"].data
+            # Betting data dates are correct, but the times are arbitrarily set by the
+            # parser, so better to leave the date definition to a different data source
+            betting_data = self.data_readers["betting"].data.drop("date", axis=1)
 
             self._data = (
                 self._compose_transformers(  # pylint: disable=E1102

--- a/backend/machine_learning/ml_data/match_ml_data.py
+++ b/backend/machine_learning/ml_data/match_ml_data.py
@@ -54,7 +54,6 @@ FEATURE_FUNCS: List[DataFrameTransformer] = [
     ),
     add_cum_win_points,
     add_win_streak,
-    add_elo_rating,
     feature_calculator(
         [
             (calculate_rolling_rate, [("prev_match_result",)]),
@@ -73,6 +72,11 @@ FEATURE_FUNCS: List[DataFrameTransformer] = [
     ),
 ]
 DATA_TRANSFORMERS: List[DataFrameTransformer] = [
+    # add_elo_rating depends on DF still being organized per-match
+    # with home_team/away_team columns
+    FeatureBuilder(
+        index_cols=["home_team", "year", "round_number"], feature_funcs=[add_elo_rating]
+    ).transform,
     TeamDataStacker(index_cols=INDEX_COLS).transform,
     FeatureBuilder(feature_funcs=FEATURE_FUNCS).transform,
     OppoFeatureBuilder(
@@ -93,6 +97,8 @@ DATA_TRANSFORMERS: List[DataFrameTransformer] = [
             # "oppo_result",
             "margin",
             "oppo_margin",
+            "elo_rating",
+            "oppo_elo_rating",
             "out_of_state",
             "at_home",
             "oppo_team",

--- a/backend/machine_learning/ml_data/player_ml_data.py
+++ b/backend/machine_learning/ml_data/player_ml_data.py
@@ -143,10 +143,7 @@ class PlayerMLData(BaseMLData, DataTransformerMixin):
             round_number = self.__upcoming_round_number(match_data, current_year)
             roster_data_reader, roster_data_kwargs = self.data_readers["roster"]
             return roster_data_reader(
-                **{
-                    **roster_data_kwargs,
-                    **{"round_number": round_number, "year": current_year},
-                }
+                round_number, **{**roster_data_kwargs, **{"year": current_year}}
             )
 
         return None

--- a/backend/machine_learning/ml_data/player_ml_data.py
+++ b/backend/machine_learning/ml_data/player_ml_data.py
@@ -35,6 +35,7 @@ MATCH_STATS_COLS = [
     "oppo_team",
     "year",
     "round_number",
+    "date",
 ]
 
 FEATURE_FUNCS: List[DataFrameTransformer] = [

--- a/backend/machine_learning/tests/integration/data_import/test_afl_data_importer.py
+++ b/backend/machine_learning/tests/integration/data_import/test_afl_data_importer.py
@@ -4,11 +4,11 @@ import pandas as pd
 from machine_learning.data_import import afl_data_importer
 
 
-class TestAflDataReader(TestCase):
+class TestAflDataImporter(TestCase):
     def setUp(self):
-        self.data_reader = afl_data_importer
+        self.data_importer = afl_data_importer
 
     def test_get_rosters(self):
-        data_frame = self.data_reader.get_rosters()
+        data_frame = self.data_importer.get_rosters(1)
 
         self.assertIsInstance(data_frame, pd.DataFrame)

--- a/backend/machine_learning/tests/integration/data_import/test_footywire_data_importer.py
+++ b/backend/machine_learning/tests/integration/data_import/test_footywire_data_importer.py
@@ -23,6 +23,7 @@ class TestFootywireDataImporter(TestCase):
             self.assertEqual(len(seasons), 1)
             self.assertEqual(seasons.iloc[0], 2004)
 
+            self.assertEqual(data_frame["date"].dtype, "datetime64[ns]")
             date_years = data_frame["date"].dt.year.drop_duplicates()
             self.assertEqual(len(date_years), 1)
             self.assertEqual(date_years.iloc[0], 2004)
@@ -32,6 +33,7 @@ class TestFootywireDataImporter(TestCase):
 
             self.assertIsInstance(data_frame, pd.DataFrame)
             self.assertFalse(data_frame.empty)
+            self.assertEqual(data_frame["date"].dtype, "datetime64[ns]")
 
         with self.subTest("when fetch_data is False and year_range is specified"):
             data_frame = self.data_reader.get_fixture(
@@ -55,9 +57,8 @@ class TestFootywireDataImporter(TestCase):
             self.assertEqual(len(seasons), 1)
             self.assertEqual(seasons.iloc[0], 2014)
 
-            # 'date' column is python datetime, not pandas datetime, so we have to
-            # convert it before calling .dt
-            date_years = pd.to_datetime(data_frame["date"]).dt.year.drop_duplicates()
+            self.assertEqual(data_frame["date"].dtype, "datetime64[ns]")
+            date_years = data_frame["date"].dt.year.drop_duplicates()
             self.assertEqual(len(date_years), 1)
             self.assertEqual(date_years.iloc[0], 2014)
 
@@ -66,6 +67,7 @@ class TestFootywireDataImporter(TestCase):
 
             self.assertIsInstance(data_frame, pd.DataFrame)
             self.assertFalse(data_frame.empty)
+            self.assertEqual(data_frame["date"].dtype, "datetime64[ns]")
 
         with self.subTest("when fetch_data is False and year_range is specified"):
             data_frame = self.data_reader.get_betting_odds(

--- a/backend/machine_learning/tests/unit/data_processors/test_feature_builder.py
+++ b/backend/machine_learning/tests/unit/data_processors/test_feature_builder.py
@@ -4,7 +4,6 @@ import pandas as pd
 import numpy as np
 
 from machine_learning.data_processors import FeatureBuilder
-from machine_learning.data_processors.feature_builder import REQUIRED_COLS
 
 FAKE = Faker()
 
@@ -48,7 +47,7 @@ class TestFeatureBuilder(TestCase):
             self.assertIn("new_col", transformed_df.columns)
             self.assertIn("newer_col", transformed_df.columns)
 
-        for required_col in REQUIRED_COLS:
+        for required_col in self.builder.index_cols:
             with self.subTest(data_frame=valid_data_frame.drop(required_col, axis=1)):
                 data_frame = valid_data_frame.drop(required_col, axis=1)
 

--- a/backend/machine_learning/tests/unit/data_processors/test_player_data_aggregator.py
+++ b/backend/machine_learning/tests/unit/data_processors/test_player_data_aggregator.py
@@ -1,4 +1,5 @@
 from unittest import TestCase
+from datetime import datetime
 from faker import Faker
 import pandas as pd
 import numpy as np
@@ -8,6 +9,7 @@ from machine_learning.data_processors.player_data_aggregator import (
     REQUIRED_COLS,
     STATS_COLS,
 )
+from project.settings.common import MELBOURNE_TIMEZONE
 
 FAKE = Faker()
 N_ROWS = 10
@@ -24,6 +26,8 @@ class TestPlayerDataAggregator(TestCase):
         self.data_frame = pd.DataFrame(
             {
                 **{
+                    "date": [datetime(2014, 6, 15, 13, tzinfo=MELBOURNE_TIMEZONE)]
+                    * N_ROWS,
                     "team": sorted(teams * int(N_ROWS / 2)),
                     "oppo_team": list(reversed(sorted(teams * int(N_ROWS / 2)))),
                     "year": [2014] * N_ROWS,

--- a/backend/machine_learning/tests/unit/data_processors/test_team_data_stacker.py
+++ b/backend/machine_learning/tests/unit/data_processors/test_team_data_stacker.py
@@ -1,4 +1,5 @@
 from unittest import TestCase
+from datetime import datetime
 from faker import Faker
 import pandas as pd
 import numpy as np
@@ -16,6 +17,7 @@ class TestTeamDataStacker(TestCase):
         # DataFrame w/ minimum valid columns
         valid_data_frame = pd.DataFrame(
             {
+                "date": [datetime(2000, 4, 15, 7)] * 10,
                 "home_team": [FAKE.company() for _ in range(10)],
                 "away_team": [FAKE.company() for _ in range(10)],
                 "year": [FAKE.year() for _ in range(10)],
@@ -27,6 +29,7 @@ class TestTeamDataStacker(TestCase):
 
         invalid_data_frame = pd.DataFrame(
             {
+                "date": [datetime(2000, 4, 15, 7)] * 10,
                 "home_team": [FAKE.company() for _ in range(10)],
                 "away_team": [FAKE.company() for _ in range(10)],
                 "round_number": [np.random.randint(1, 24) for _ in range(10)],

--- a/backend/machine_learning/tests/unit/data_transformation/test_data_cleaning.py
+++ b/backend/machine_learning/tests/unit/data_transformation/test_data_cleaning.py
@@ -1,5 +1,6 @@
 import os
 from unittest import TestCase
+from datetime import datetime
 import pandas as pd
 from faker import Faker
 
@@ -18,7 +19,9 @@ FAKE = Faker()
 
 class TestDataCleaning(TestCase):
     def test_clean_betting_data(self):
-        betting_data = pd.read_csv(os.path.join(DATA_DIR, "afl_betting.csv"))
+        betting_data = pd.read_csv(
+            os.path.join(DATA_DIR, "afl_betting.csv"), parse_dates=["date"]
+        )
 
         clean_data = clean_betting_data(betting_data)
 
@@ -59,6 +62,7 @@ class TestDataCleaning(TestCase):
         with self.subTest("with roster data for upcoming matches"):
             roster_data = pd.DataFrame(
                 {
+                    "date": [datetime(2019, 3, 20, 7)] * N_PLAYERS,
                     "round_number": [1] * N_PLAYERS,
                     "year": [2019] * N_PLAYERS,
                     "match_id": list(range(N_PLAYERS)),

--- a/backend/machine_learning/tests/unit/ml_data/test_joined_ml_data.py
+++ b/backend/machine_learning/tests/unit/ml_data/test_joined_ml_data.py
@@ -1,4 +1,5 @@
 import os
+from datetime import datetime
 from unittest import TestCase
 from unittest.mock import Mock
 import pandas as pd
@@ -6,6 +7,7 @@ from faker import Faker
 
 from machine_learning.ml_data import JoinedMLData
 from machine_learning.data_transformation import data_cleaning
+from project.settings.common import MELBOURNE_TIMEZONE
 
 DATA_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../fixtures"))
 FAKE = Faker()
@@ -21,6 +23,7 @@ class TestJoinedMLData(TestCase):
         base_data = pd.DataFrame(
             [
                 {
+                    "date": datetime(2016, 3, 20, 14, tzinfo=MELBOURNE_TIMEZONE),
                     "team": teams[n % (N_TEAMS - 1)],
                     "oppo_team": teams[-(n % (N_TEAMS - 1))],
                     "year": 2016,

--- a/backend/server/management/commands/tip.py
+++ b/backend/server/management/commands/tip.py
@@ -244,6 +244,13 @@ class Command(BaseCommand):
         loaded_model = joblib.load(os.path.join(BASE_DIR, ml_model_record.filepath))
         self.data.test_years = (year, year)
         X_test, _ = self.data.test_data(test_round=round_number)
+
+        if not X_test.any().any():
+            raise ValueError(
+                "X_test doesn't have any rows, likely due to some data for the "
+                "upcoming round not being available yet."
+            )
+
         y_pred = loaded_model.predict(X_test)
 
         data_row_slice = (slice(None), year, slice(round_number, round_number))


### PR DESCRIPTION
Main purpose of this PR is to speed up ELO rating calculation, which was about 7 mins, 7 secs, but now runs in about 1 sec. As with other recent data transformation changes, however, this revealed a fair number of silent bugs in the data, and it seems that I forgot to merge some earlier fixes, so those got added here.