### PR TITLE
Cf/fix seed scores

### DIFF
--- a/backend/machine_learning/data_import/footywire_data_importer.py
+++ b/backend/machine_learning/data_import/footywire_data_importer.py
@@ -88,6 +88,8 @@ class FootywireDataImporter:
         """
 
         if fetch_data:
+            print(f"Fetching fixture data in the year range of {year_range}...")
+
             return self.__clean_fixture_data_frame(
                 self.__fetch_data(FIXTURE_PATH, year_range)
             )
@@ -108,6 +110,8 @@ class FootywireDataImporter:
         """
 
         if fetch_data:
+            print(f"Fetching betting data in the year range of {year_range}...")
+
             return self.__fetch_data(BETTING_PATH, year_range).pipe(
                 self.__clean_betting_data_frame
             )
@@ -161,6 +165,8 @@ class FootywireDataImporter:
 
         data = list(itertools.chain.from_iterable(yearly_data))
         columns = FIXTURE_COLS if url_path == FIXTURE_PATH else BETTING_COLS
+
+        print("Data received!")
 
         return pd.DataFrame(data, columns=columns)
 

--- a/backend/server/management/commands/seed_db.py
+++ b/backend/server/management/commands/seed_db.py
@@ -173,6 +173,10 @@ class Command(BaseCommand):
                     "\tCould not find any ML models in DB to make predictions."
                 )
 
+        # Loading the data here, because it makes for a weird set of messages to do it
+        # in the middle of loading models & making predictions
+        self.data.data
+
         make_model_predictions = partial(
             self.__make_model_predictions, year_range, round_number=round_number
         )

--- a/backend/server/management/commands/seed_db.py
+++ b/backend/server/management/commands/seed_db.py
@@ -175,7 +175,7 @@ class Command(BaseCommand):
 
         # Loading the data here, because it makes for a weird set of messages to do it
         # in the middle of loading models & making predictions
-        self.data.data
+        self.data.data  # pylint: disable=W0104
 
         make_model_predictions = partial(
             self.__make_model_predictions, year_range, round_number=round_number

--- a/backend/server/management/commands/seed_db.py
+++ b/backend/server/management/commands/seed_db.py
@@ -24,6 +24,8 @@ FixtureData = TypedDict(
         "round": int,
         "home_team": str,
         "away_team": str,
+        "home_score": int,
+        "away_score": int,
         "venue": str,
     },
 )
@@ -299,10 +301,10 @@ class Command(BaseCommand):
         away_team = Team.objects.get(name=match_data["away_team"])
 
         home_team_match = TeamMatch(
-            team=home_team, match=match, at_home=True, score=NO_SCORE
+            team=home_team, match=match, at_home=True, score=match_data["home_score"]
         )
         away_team_match = TeamMatch(
-            team=away_team, match=match, at_home=False, score=NO_SCORE
+            team=away_team, match=match, at_home=False, score=match_data["away_score"]
         )
 
         home_team_match.clean_fields()

--- a/backend/server/tests/integration/management/commands/test_seed_db.py
+++ b/backend/server/tests/integration/management/commands/test_seed_db.py
@@ -76,6 +76,7 @@ class TestSeedDb(TestCase):
         self.assertEqual(
             Prediction.objects.count(), ROW_COUNT * len(range(*self.years))
         )
+        self.assertEqual(TeamMatch.objects.filter(score=0).count(), 0)
 
     def test_handle_errors(self):
         with self.subTest(


### PR DESCRIPTION
Resolves #67 

A copy/paste bug meant that 0 scores from `tip` ended up in `seed_db` as well. I fixed it by getting actual scores from the match data.