### PR TITLE
Cf/fix r dependencies

### DIFF
--- a/afl_data/.gitignore
+++ b/afl_data/.gitignore
@@ -1,0 +1,1 @@
+.Rhistory

--- a/afl_data/DESCRIPTION
+++ b/afl_data/DESCRIPTION
@@ -11,7 +11,8 @@ Imports:
     BH,
     plumber,
     progress,
-    tidyverse,
+    dplyr,
+    stringr,
     plogr,
     fitzRoy
 Remotes:

--- a/afl_data/R/app.R
+++ b/afl_data/R/app.R
@@ -1,4 +1,5 @@
-library("tidyverse")
+library("dplyr")
+library("stringr")
 
 pr <- plumber::plumb("R/plumber.R")
 pr$run(host = "0.0.0.0", port = 8001)

--- a/afl_data/R/plumber.R
+++ b/afl_data/R/plumber.R
@@ -1,3 +1,6 @@
+MIN_SEASONS_FOR_PREDICTION_DATA = 2
+this_year <- Sys.Date() %>% substring(0, 4) %>% as.integer()
+
 #' Return match results data
 #' @param fetch_data Whether to fetch fresh data from afltables.com
 #' @get /matches
@@ -22,6 +25,35 @@ function(fetch_data = FALSE) {
 #' because that's all we need for predictions, and it keeps RAM usage
 #' to a minimum
 function(start_date = "2017-01-01", end_date = Sys.Date()) {
+  handle_players_route_error <- function(start_date, end_date) {
+    end_date_year <- end_date %>% substring(0, 4) %>% as.integer()
+
+    function(err) {
+      if (end_date_year > this_year) {
+        retry_with_last_year_end_date(start_date, end_date)
+      } else {
+        stop(err)
+      }
+    }
+  }
+
+  retry_with_last_year_end_date <- function(start_date, end_date) {
+      end_date_last_year <- paste0(this_year - 1, "-12-31")
+
+      warning(
+        paste0(
+          "end_date of ", end_date, " is in a year for which AFLTables has no ",
+          "data. Retrying with an end_date of the end of last year: ",
+          end_date_last_year
+        )
+      )
+
+      fitzRoy::get_afltables_stats(
+        start_date = start_date,
+        end_date = end_date_last_year
+      )
+  }
+
   data <- tryCatch({
       fitzRoy::get_afltables_stats(start_date = start_date, end_date = end_date)
     },
@@ -33,38 +65,3 @@ function(start_date = "2017-01-01", end_date = Sys.Date()) {
     rename_all(funs(str_to_lower(.) %>% str_replace_all(., "\\.", "_"))) %>%
     jsonlite::toJSON()
 }
-
-# Private functions
-
-handle_players_route_error <- function(start_date, end_date) {
-  end_date_year <- end_date %>% substring(0, 4) %>% as.integer()
-
-  function(err) {
-    if (end_date_year > this_year) {
-      retry_with_last_year_end_date(start_date, end_date)
-    } else {
-      stop(err)
-    }
-  }
-}
-
-retry_with_last_year_end_date <- function(start_date, end_date) {
-    end_date_last_year <- paste0(this_year - 1, "-12-31")
-
-    warning(
-      paste0(
-        "end_date of ", end_date, " is in a year for which AFLTables has no ",
-        "data. Retrying with an end_date of the end of last year: ",
-        end_date_last_year
-      )
-    )
-
-    fitzRoy::get_afltables_stats(
-      start_date = start_date,
-      end_date = end_date_last_year
-    )
-}
-
-this_year <- Sys.Date() %>% substring(0, 4) %>% as.integer()
-
-MIN_SEASONS_FOR_PREDICTION_DATA = 2

--- a/afl_data/R/plumber.R
+++ b/afl_data/R/plumber.R
@@ -9,6 +9,7 @@ function(fetch_data = FALSE) {
   }
 
   data %>%
+    filter(., Season >= this_year - MIN_SEASONS_FOR_PREDICTION_DATA) %>%
     rename_all(funs(str_to_lower(.) %>% str_replace_all(., "\\.", "_"))) %>%
     jsonlite::toJSON()
 }
@@ -17,8 +18,10 @@ function(fetch_data = FALSE) {
 #' @param start_date Minimum match date for fetched data
 #' @param end_date Maximum match date for fetched data
 #' @get /players
-#' AFL Tables data starts in 1897
-function(start_date = "1897-01-01", end_date = Sys.Date()) {
+#' AFL Tables data starts in 1897, but making default 2 years ago,
+#' because that's all we need for predictions, and it keeps RAM usage
+#' to a minimum
+function(start_date = "2017-01-01", end_date = Sys.Date()) {
   data <- tryCatch({
       fitzRoy::get_afltables_stats(start_date = start_date, end_date = end_date)
     },
@@ -26,6 +29,7 @@ function(start_date = "1897-01-01", end_date = Sys.Date()) {
   )
 
   data %>%
+    filter(., Season >= this_year - MIN_SEASONS_FOR_PREDICTION_DATA) %>%
     rename_all(funs(str_to_lower(.) %>% str_replace_all(., "\\.", "_"))) %>%
     jsonlite::toJSON()
 }
@@ -62,3 +66,5 @@ retry_with_last_year_end_date <- function(start_date, end_date) {
 }
 
 this_year <- Sys.Date() %>% substring(0, 4) %>% as.integer()
+
+MIN_SEASONS_FOR_PREDICTION_DATA = 2

--- a/afl_data/R/plumber.R
+++ b/afl_data/R/plumber.R
@@ -4,7 +4,7 @@ this_year <- Sys.Date() %>% substring(0, 4) %>% as.integer()
 #' Return match results data
 #' @param fetch_data Whether to fetch fresh data from afltables.com
 #' @get /matches
-function(fetch_data = FALSE) {
+function(fetch_data = FALSE, full_season_count = MIN_SEASONS_FOR_PREDICTION_DATA) {
   data <- if (fetch_data) {
     fitzRoy::get_match_results()
   } else {
@@ -12,7 +12,7 @@ function(fetch_data = FALSE) {
   }
 
   data %>%
-    filter(., Season >= this_year - MIN_SEASONS_FOR_PREDICTION_DATA) %>%
+    filter(., Season >= this_year - full_season_count) %>%
     rename_all(funs(str_to_lower(.) %>% str_replace_all(., "\\.", "_"))) %>%
     jsonlite::toJSON()
 }
@@ -24,7 +24,11 @@ function(fetch_data = FALSE) {
 #' AFL Tables data starts in 1897, but making default 2 years ago,
 #' because that's all we need for predictions, and it keeps RAM usage
 #' to a minimum
-function(start_date = "2017-01-01", end_date = Sys.Date()) {
+function(
+  start_date = "2017-01-01",
+  end_date = Sys.Date(),
+  full_season_count = MIN_SEASONS_FOR_PREDICTION_DATA
+) {
   handle_players_route_error <- function(start_date, end_date) {
     end_date_year <- end_date %>% substring(0, 4) %>% as.integer()
 
@@ -61,7 +65,7 @@ function(start_date = "2017-01-01", end_date = Sys.Date()) {
   )
 
   data %>%
-    filter(., Season >= this_year - MIN_SEASONS_FOR_PREDICTION_DATA) %>%
+    filter(., Season >= this_year - full_season_count) %>%
     rename_all(funs(str_to_lower(.) %>% str_replace_all(., "\\.", "_"))) %>%
     jsonlite::toJSON()
 }

--- a/backend/machine_learning/data_transformation/data_cleaning.py
+++ b/backend/machine_learning/data_transformation/data_cleaning.py
@@ -51,8 +51,6 @@ UNUSED_PLAYER_COLS = [
     "umpire_2",
     "umpire_3",
     "umpire_4",
-    "substitute",
-    "group_id",
 ]
 
 PLAYER_FILLNA = {


### PR DESCRIPTION
Moving `fitzRoy` to a separate R-based service had the unintended consequence of blowing out memory usage when loading the full data set. Since I only need the full data set for training and analysis, both of which I do offline, I added a filter to drop the extra data that we don't need for predictions.