### PR TITLE
Cf/fix seed data filter

### DIFF
--- a/afl_data/R/plumber.R
+++ b/afl_data/R/plumber.R
@@ -1,10 +1,11 @@
-MIN_SEASONS_FOR_PREDICTION_DATA = 2
-this_year <- Sys.Date() %>% substring(0, 4) %>% as.integer()
+FIRST_AFL_SEASON = '1897-01-01'
 
 #' Return match results data
 #' @param fetch_data Whether to fetch fresh data from afltables.com
+#' @param start_date Minimum match date for fetched data
+#' @param end_date Maximum match date for fetched data
 #' @get /matches
-function(fetch_data = FALSE, full_season_count = MIN_SEASONS_FOR_PREDICTION_DATA) {
+function(fetch_data = FALSE, start_date = FIRST_AFL_SEASON, end_date = Sys.Date()) {
   data <- if (fetch_data) {
     fitzRoy::get_match_results()
   } else {
@@ -12,7 +13,7 @@ function(fetch_data = FALSE, full_season_count = MIN_SEASONS_FOR_PREDICTION_DATA
   }
 
   data %>%
-    filter(., Season >= this_year - full_season_count) %>%
+    filter(., Date >= start_date & Date <= end_date) %>%
     rename_all(funs(str_to_lower(.) %>% str_replace_all(., "\\.", "_"))) %>%
     jsonlite::toJSON()
 }
@@ -21,14 +22,9 @@ function(fetch_data = FALSE, full_season_count = MIN_SEASONS_FOR_PREDICTION_DATA
 #' @param start_date Minimum match date for fetched data
 #' @param end_date Maximum match date for fetched data
 #' @get /players
-#' AFL Tables data starts in 1897, but making default 2 years ago,
-#' because that's all we need for predictions, and it keeps RAM usage
-#' to a minimum
-function(
-  start_date = "2017-01-01",
-  end_date = Sys.Date(),
-  full_season_count = MIN_SEASONS_FOR_PREDICTION_DATA
-) {
+function(start_date = FIRST_AFL_SEASON, end_date = Sys.Date()) {
+  this_year <- Sys.Date() %>% substring(0, 4) %>% as.integer()
+
   handle_players_route_error <- function(start_date, end_date) {
     end_date_year <- end_date %>% substring(0, 4) %>% as.integer()
 
@@ -65,7 +61,7 @@ function(
   )
 
   data %>%
-    filter(., Season >= this_year - full_season_count) %>%
+    filter(., Date >= start_date & Date <= end_date) %>%
     rename_all(funs(str_to_lower(.) %>% str_replace_all(., "\\.", "_"))) %>%
     jsonlite::toJSON()
 }

--- a/backend/machine_learning/data_import/fitzroy_data_importer.py
+++ b/backend/machine_learning/data_import/fitzroy_data_importer.py
@@ -21,7 +21,12 @@ AFL_DATA_SERVICE = "http://afl_data:8001"
 class FitzroyDataImporter:
     """Get data from the fitzRoy R package and return it as a pandas DataFrame."""
 
-    def match_results(self, fetch_data: bool = False) -> pd.DataFrame:
+    def match_results(
+        self,
+        fetch_data: bool = False,
+        start_date: str = "1897-01-01",
+        end_date: str = str(date.today()),
+    ) -> pd.DataFrame:
         """Get match results data.
 
         Args:
@@ -32,9 +37,16 @@ class FitzroyDataImporter:
             pandas.DataFrame
         """
 
-        print("Fetching match data...")
+        print(f"Fetching match data from between {start_date} and {end_date}...")
 
-        data = self.__fetch_afl_data("matches", params={"fetch_data": fetch_data})
+        data = self.__fetch_afl_data(
+            "matches",
+            params={
+                "fetch_data": fetch_data,
+                "start_date": start_date,
+                "end_date": end_date,
+            },
+        )
 
         print("Match data received!")
 

--- a/backend/machine_learning/data_processors/feature_functions.py
+++ b/backend/machine_learning/data_processors/feature_functions.py
@@ -18,7 +18,13 @@ import pandas as pd
 import numpy as np
 from sklearn.preprocessing import LabelEncoder
 
-from machine_learning.data_config import INDEX_COLS, CITIES, TEAM_CITIES, VENUE_CITIES
+from machine_learning.data_config import (
+    INDEX_COLS,
+    CITIES,
+    TEAM_CITIES,
+    VENUE_CITIES,
+    AVG_SEASON_LENGTH,
+)
 
 EloDictionary = TypedDict(
     "EloDictionary",
@@ -364,7 +370,7 @@ def add_rolling_player_stats(data_frame: pd.DataFrame):
         .groupby("player_id", group_keys=False)
     )
 
-    rolling_stats = player_groups.rolling(window=23).mean()
+    rolling_stats = player_groups.rolling(window=AVG_SEASON_LENGTH).mean()
     expanding_stats = player_groups.expanding(1).mean()
 
     player_stats = rolling_stats.fillna(expanding_stats).sort_index()

--- a/backend/machine_learning/ml_data/base_ml_data.py
+++ b/backend/machine_learning/ml_data/base_ml_data.py
@@ -1,6 +1,7 @@
 """Module for base class for machine learning data class"""
 
 from typing import Tuple
+from datetime import date
 
 import pandas as pd
 
@@ -19,10 +20,14 @@ class BaseMLData:
         train_years: YearPair = (None, 2015),
         test_years: YearPair = (2016, 2016),
         fetch_data: bool = False,
+        start_date: str = "1897-01-01",
+        end_date: str = str(date.today()),
     ) -> None:
         self._train_years = train_years
         self._test_years = test_years
         self.fetch_data = fetch_data
+        self.start_date = start_date
+        self.end_date = end_date
 
     def train_data(self) -> Tuple[pd.DataFrame, pd.DataFrame]:
         """Filter data by year to produce training data"""

--- a/backend/machine_learning/ml_data/joined_ml_data.py
+++ b/backend/machine_learning/ml_data/joined_ml_data.py
@@ -1,6 +1,7 @@
 """Module for machine learning data class that joins various data sources together"""
 
 from typing import List, Dict
+from datetime import date
 import pandas as pd
 
 from machine_learning.data_processors import FeatureBuilder
@@ -73,9 +74,15 @@ class JoinedMLData(BaseMLData, DataTransformerMixin):
         category_cols: List[str] = CATEGORY_COLS,
         data_transformers: List[DataFrameTransformer] = DATA_TRANSFORMERS,
         fetch_data: bool = False,
+        start_date: str = "1897-01-01",
+        end_date: str = str(date.today()),
     ) -> None:
         super().__init__(
-            train_years=train_years, test_years=test_years, fetch_data=fetch_data
+            train_years=train_years,
+            test_years=test_years,
+            fetch_data=fetch_data,
+            start_date=start_date,
+            end_date=end_date,
         )
 
         self._data_transformers = data_transformers
@@ -87,9 +94,15 @@ class JoinedMLData(BaseMLData, DataTransformerMixin):
     def data(self) -> pd.DataFrame:
         if self._data is None:
             self.data_readers["player"].fetch_data = self.fetch_data
+            self.data_readers["player"].start_date = self.start_date
+            self.data_readers["player"].end_date = self.end_date
             player_data = self.data_readers["player"].data
+
             self.data_readers["match"].fetch_data = self.fetch_data
+            self.data_readers["match"].start_date = self.start_date
+            self.data_readers["match"].end_date = self.end_date
             match_data = self.data_readers["match"].data
+
             self.data_readers["betting"].fetch_data = self.fetch_data
             # Betting data dates are correct, but the times are arbitrarily set by the
             # parser, so better to leave the date definition to a different data source

--- a/backend/machine_learning/ml_data/match_ml_data.py
+++ b/backend/machine_learning/ml_data/match_ml_data.py
@@ -1,7 +1,7 @@
 """Module with wrapper class for XGBoost model and its associated data class"""
 
 from typing import List, Callable
-from datetime import datetime
+from datetime import datetime, date
 import pandas as pd
 
 from machine_learning.types import DataFrameTransformer, YearPair, DataReadersParam
@@ -140,9 +140,15 @@ class MatchMLData(BaseMLData, DataTransformerMixin):
         test_years: YearPair = (2016, 2016),
         index_cols: List[str] = INDEX_COLS,
         fetch_data: bool = False,
+        start_date: str = "1897-01-01",
+        end_date: str = str(date.today()),
     ) -> None:
         super().__init__(
-            train_years=train_years, test_years=test_years, fetch_data=fetch_data
+            train_years=train_years,
+            test_years=test_years,
+            fetch_data=fetch_data,
+            start_date=start_date,
+            end_date=end_date,
         )
 
         self._data_transformers = data_transformers
@@ -158,7 +164,14 @@ class MatchMLData(BaseMLData, DataTransformerMixin):
         if self._data is None:
             match_data_reader, match_data_kwargs = self.data_readers["match"]
             match_data = match_data_reader(
-                **{**match_data_kwargs, **{"fetch_data": self.fetch_data}}
+                **{
+                    **match_data_kwargs,
+                    **{
+                        "fetch_data": self.fetch_data,
+                        "start_date": self.start_date,
+                        "end_date": self.end_date,
+                    },
+                }
             )
 
             if self.fetch_data and "fixture" in self.data_readers.keys():

--- a/backend/machine_learning/ml_data/player_ml_data.py
+++ b/backend/machine_learning/ml_data/player_ml_data.py
@@ -99,9 +99,15 @@ class PlayerMLData(BaseMLData, DataTransformerMixin):
         test_years: YearPair = (2016, 2016),
         index_cols: List[str] = INDEX_COLS,
         fetch_data: bool = False,
+        start_date: str = "1897-01-01",
+        end_date: str = str(date.today()),
     ) -> None:
         super().__init__(
-            train_years=train_years, test_years=test_years, fetch_data=fetch_data
+            train_years=train_years,
+            test_years=test_years,
+            fetch_data=fetch_data,
+            start_date=start_date,
+            end_date=end_date,
         )
 
         self._data_transformers = data_transformers
@@ -114,11 +120,23 @@ class PlayerMLData(BaseMLData, DataTransformerMixin):
     def data(self):
         if self._data is None:
             player_data_reader, player_data_kwargs = self.data_readers["player"]
-            player_data = player_data_reader(**player_data_kwargs)
+            player_data = player_data_reader(
+                **{
+                    **player_data_kwargs,
+                    **{"start_date": self.start_date, "end_date": self.end_date},
+                }
+            )
 
             match_data_reader, match_data_kwargs = self.data_readers["match"]
             match_data = match_data_reader(
-                **{**match_data_kwargs, **{"fetch_data": self.fetch_data}}
+                **{
+                    **match_data_kwargs,
+                    **{
+                        "fetch_data": self.fetch_data,
+                        "start_date": self.start_date,
+                        "end_date": self.end_date,
+                    },
+                }
             )
             roster_data = self.__roster_data(match_data)
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -11,6 +11,7 @@ services:
     tty: true
     depends_on:
       - db
+      - afl_data
     env_file: .env
     environment:
       - DJANGO_SETTINGS_MODULE=project.settings.production
@@ -27,6 +28,7 @@ services:
     tty: true
     networks:
       - webnet
+    restart: unless-stopped
     command: Rscript R/app.R
   db:
     image: postgres


### PR DESCRIPTION
Resolves #73 

When I fixed the issue with loading the full data set blowing out the memory usage by filtering out older data, I neglected to update `seed_db` to make sure it got the full data set for training. I added `start_date` and `end_date` params to all data-related classes to give more control on how much data is loaded by different processes.